### PR TITLE
fix sms helper bug does not working properly

### DIFF
--- a/src/pm-qrcode.vue
+++ b/src/pm-qrcode.vue
@@ -123,7 +123,7 @@ export default {
           this.textToQR = `tel:${this.value || 0}`;
           break;
         case "sms":
-          this.textToQR = `sms:${this.value.number || 0}${
+          this.textToQR = `SMSTO:${this.value.number || 0}${
             this.value.message ? ":" + this.value.message : ""
           }`;
           break;


### PR DESCRIPTION
I found that the "sms helper" doesn't work properly, when scanning the QR it append the message to the number. after a long time of research i found that the issue is in "sms:phoneNumber:message" it should be "SMSTO:phoneNumber:message" to work properly. So, i did fix the issue and i hope you see it as a good fix to the issue.